### PR TITLE
add option to set default configuration from pd.DataFrame

### DIFF
--- a/src/irace/__init__.py
+++ b/src/irace/__init__.py
@@ -79,9 +79,13 @@ class irace:
         # collected by Python and crash later.
         self.r_target_runner = make_target_runner(target_runner)
 
-    def read_configurations(self, filename=None, text=None):
-        if text is None:
+    def read_configurations(self, filename=None, text=None, r_data_frame=None):
+        if r_data_frame is None and filename is None and text is not None:
+            confs = self._pkg.readConfigurationsFile(text = text, parameters = self.parameters)
+        elif r_data_frame is None and filename is not None:
             confs = self._pkg.readConfigurationsFile(filename = filename, parameters = self.parameters)
+        elif r_data_frame is not None:
+            confs = self._pkg.readConfigurationsFile(configurationTable = r_data_frame, parameters = self.parameters)
         else:
             confs = self._pkg.readConfigurationsFile(text = text, parameters = self.parameters)
         # FIXME: can we save this converter to use it every where?
@@ -99,7 +103,15 @@ class irace:
         confs = self.read_configurations(text = text)
         self.set_initial(confs)
         return confs
-    
+
+    def set_initial_from_data_frame(self, data_frame):
+        with localconverter(ro.default_converter + pandas2ri.converter):
+            rdf = ro.conversion.py2rpy(data_frame)
+        print(rdf)
+        confs = self.read_configurations(r_data_frame = rdf)
+        self.set_initial(confs)
+        return confs
+
     def set_initial(self, x):
         if isinstance(x, pd.DataFrame):
             x = x.to_records(index=False)

--- a/tests/test_read_configurations.py
+++ b/tests/test_read_configurations.py
@@ -1,0 +1,31 @@
+import numpy as np 
+from irace import irace
+import pandas as pd
+
+import json
+def target_runner(experiment, scenario):
+    return dict(cost=experiment['configuration']['one'])
+
+
+params = '''
+one "" r (0, 1)
+'''
+
+defaults = pd.DataFrame(data=dict(
+    one=[0.6]
+))
+
+scenario = dict(
+    instances = np.arange(10),
+    maxExperiments = 96,
+    debugLevel = 0,
+    parallel = 1,
+    logfile = ""
+)
+
+
+def test_default_digits():
+    tuner = irace(scenario, params, target_runner)
+    tuner.set_initial_from_data_frame(defaults)
+    best_conf = tuner.run()
+    print(best_conf)


### PR DESCRIPTION
This is useful for people who want to programmatically set their default configuration. It also would avoid floating point precision loss when converting to and fro text. 

Depends on MLopez-Ibanez/irace#48.