### PR TITLE
Restructure Parallel Runner

### DIFF
--- a/tests/test_daemon_process.py
+++ b/tests/test_daemon_process.py
@@ -4,15 +4,11 @@ import numpy as np
 from irace import irace
 import pandas as pd
 from multiprocessing import Process
-import os
 
 import json
 def target_runner(experiment, scenario):
     Process(target=print, args=(1,)).start()
     return dict(cost=experiment['configuration']['one'])
-
-def is_windows():
-    return os.name == 'nt'
 
 params = '''
 one "" r (0, 1)
@@ -32,8 +28,6 @@ scenario = dict(
 
 
 def test():
-    if is_windows():
-        return
     tuner = irace(scenario, params, target_runner)
     tuner.set_initial(defaults)
     best_conf = tuner.run()

--- a/tests/test_dual_annealing.py
+++ b/tests/test_dual_annealing.py
@@ -37,18 +37,13 @@ instances = np.arange(100)
 
 # See https://mlopez-ibanez.github.io/irace/reference/defaultScenario.html
 
-if os.name == 'nt':
-    parallel = 1
-else:
-    parallel = 2
-
 scenario = dict(
     instances = instances,
     maxExperiments = 180,
     debugLevel = 3,
     seed = 123,
     digits = 5,
-    parallel= parallel, # It can run in parallel ! 
+    parallel= 2, # It can run in parallel ! 
     logFile = "")
 
 def run_irace(scenario, parameters_table, target_runner):
@@ -56,23 +51,6 @@ def run_irace(scenario, parameters_table, target_runner):
     tuner.set_initial_from_str(default_values)
     best_confs = tuner.run()
     # FIXME: assert type Pandas DataFrame
-    print(best_confs)
-
-def test_fail_windows():
-    # FIXME: remove when https://github.com/auto-optimization/iracepy/issues/16 is closed. 
-    if os.name == 'nt':
-        with pytest.raises(NotImplementedError):
-            scenario = dict(
-                instances = instances,
-                maxExperiments = 180,
-                debugLevel = 3,
-                seed = 123,
-                digits = 5,
-                parallel= 2, # It can run in parallel ! 
-                logFile = "")
-            tuner = irace(scenario, parameters_table, target_runner)
-            tuner.run()
-            
 
 def test_run():
     run_irace(scenario, parameters_table, target_runner)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,15 +4,11 @@ import pandas as pd
 from multiprocessing import Process, Queue
 from threading import Timer, Thread, Event
 from time import sleep
-import os
 
 BASE_TIME = 100
 
 def target_runner(experiment, scenario):
     raise ValueError()
-
-def is_windows():
-    return os.name == 'nt'
 
 params = '''
 one "" r (0, 1)
@@ -58,8 +54,6 @@ def test_no_hang1():
     assert not killed 
 
 def test_no_hang2():
-    if is_windows():
-        return
     q = Queue()
     p = Process(target=start_irace, args=(q, scenario2))
     p.start()
@@ -67,7 +61,6 @@ def test_no_hang2():
     t2 = Timer(BASE_TIME + 1, sigkill_process, args=(p,))
     t1.start()
     t2.start()
-    print("jfjfjfj")
     for i in range(BASE_TIME + 2):
         sleep(1)
         if not p.is_alive():
@@ -113,8 +106,6 @@ def test_correct_exit1():
     assert not q.empty()
 
 def test_correct_exit2():
-    if is_windows():
-        return
     q = Queue()
     p = Process(target=start_irace, args=(q, scenario2))
     p.start()


### PR DESCRIPTION
Instead of letting irace launch new target runners, we let python control the workers of target runner. This improves performance and also fixes parllel runner crashing on windows (fixes #16). I ran the `tests/test_dual_annealing`. Excluding the import and setup, the run time of the tuning was reduced from 1.46s to 0.87s. 

A few implementation details to explain:
- This does not make use of `exec.target.runner`, but instead uses `check.output.target.runner` (PR: MLopez-Ibanez/irace#49) to check the output of the target runner. I did this because I noticed that passing an r function crashes the queue so hard that it just becomes empty forever without raising any exception. Not sure why. Perhaps one day when I have more time I'll investigate it more and report the bug / submit PR to rpy2 or python. As a result, this does not benefit from the retrying function in `exec.target.runner` but it doesn't seem to be missing anything else. 
- Instead of passing the scenario object given by irace to the target runner, it keeps track of the scenario object (before it's been processed by irace). I think this is faster because there wouldn't be r to python conversion and also sometimes r objects crashes a queue as well. 
- It removes the `parllel` field from scenario before passing it to irace because otherwise irace seems to still read the parallel field and tries to do something that makes it crash on windows. 

Depends on MLopez-Ibanez/irace#49.