### PR TITLE
Pass instances

### DIFF
--- a/src/irace/__init__.py
+++ b/src/irace/__init__.py
@@ -14,6 +14,7 @@ from rpy2.rinterface_lib.sexp import NACharacterType
 from multiprocessing import Queue, Process
 import json
 from rpy2.rinterface_lib.sexp import NACharacterType
+from multiprocessing import Queue, Process
 
 irace_converter =  ro.default_converter + numpy2ri.converter + pandas2ri.converter
 

--- a/tests/test_daemon_process.py
+++ b/tests/test_daemon_process.py
@@ -4,15 +4,11 @@ import numpy as np
 from irace import irace
 import pandas as pd
 from multiprocessing import Process
-import os
 
 import json
 def target_runner(experiment, scenario):
     Process(target=print, args=(1,)).start()
     return dict(cost=experiment['configuration']['one'])
-
-def is_windows():
-    return os.name == 'nt'
 
 params = '''
 one "" r (0, 1)
@@ -32,8 +28,6 @@ scenario = dict(
 
 
 def test():
-    if is_windows():
-        return
     tuner = irace(scenario, params, target_runner)
     tuner.set_initial(defaults)
     best_conf = tuner.run()

--- a/tests/test_data_passable.py
+++ b/tests/test_data_passable.py
@@ -12,6 +12,10 @@ def target_runner(experiment, scenario):
     else:
         return dict(cost=1)
 
+def target_runner2(experiment, scenario):
+    if experiment['id.instance'] == 1:
+        experiment['instance'].put(1335)
+    return dict(cost=1)
 
 params = '''
 one "" c ('0', '1')
@@ -35,3 +39,45 @@ def test():
     best_conf = tuner.run()
     assert q.get() == 124
     
+def test_instances():
+    q = Queue()
+    scenario = dict(
+        instances = [q],
+        maxExperiments = 180,
+        debugLevel = 0,
+        parallel = 1,
+        logFile = "",
+        seed = 123
+    )
+    tuner = irace(scenario, params, target_runner2)
+    best_conf = tuner.run()
+    assert q.get() == 1335
+
+def test_instances2():
+    q = Queue()
+    scenario = dict(
+        instances = [q],
+        maxExperiments = 180,
+        debugLevel = 0,
+        parallel = 2,
+        logFile = "",
+        seed = 123
+    )
+    tuner = irace(scenario, params, target_runner2)
+    best_conf = tuner.run()
+    assert q.get() == 1335
+
+def test_default_serializer():
+    q = Queue()
+    scenario = dict(
+        instances = [q],
+        maxExperiments = 180,
+        debugLevel = 0,
+        parallel = 2,
+        logFile = "",
+        seed = 123,
+        instanceObjectSerializer = lambda x: 'hello world'
+    )
+    tuner = irace(scenario, params, target_runner2)
+    best_conf = tuner.run()
+    assert q.get() == 1335

--- a/tests/test_dual_annealing.py
+++ b/tests/test_dual_annealing.py
@@ -37,18 +37,13 @@ instances = np.arange(100)
 
 # See https://mlopez-ibanez.github.io/irace/reference/defaultScenario.html
 
-if os.name == 'nt':
-    parallel = 1
-else:
-    parallel = 2
-
 scenario = dict(
     instances = instances,
     maxExperiments = 180,
     debugLevel = 3,
     seed = 123,
     digits = 5,
-    parallel= parallel, # It can run in parallel ! 
+    parallel= 2, # It can run in parallel ! 
     logFile = "")
 
 def run_irace(scenario, parameters_table, target_runner):
@@ -56,23 +51,6 @@ def run_irace(scenario, parameters_table, target_runner):
     tuner.set_initial_from_str(default_values)
     best_confs = tuner.run()
     # FIXME: assert type Pandas DataFrame
-    print(best_confs)
-
-def test_fail_windows():
-    # FIXME: remove when https://github.com/auto-optimization/iracepy/issues/16 is closed. 
-    if os.name == 'nt':
-        with pytest.raises(NotImplementedError):
-            scenario = dict(
-                instances = instances,
-                maxExperiments = 180,
-                debugLevel = 3,
-                seed = 123,
-                digits = 5,
-                parallel= 2, # It can run in parallel ! 
-                logFile = "")
-            tuner = irace(scenario, parameters_table, target_runner)
-            tuner.run()
-            
 
 def test_run():
     run_irace(scenario, parameters_table, target_runner)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,15 +4,11 @@ import pandas as pd
 from multiprocessing import Process, Queue
 from threading import Timer, Thread, Event
 from time import sleep
-import os
 
 BASE_TIME = 100
 
 def target_runner(experiment, scenario):
     raise ValueError()
-
-def is_windows():
-    return os.name == 'nt'
 
 params = '''
 one "" r (0, 1)
@@ -58,8 +54,6 @@ def test_no_hang1():
     assert not killed 
 
 def test_no_hang2():
-    if is_windows():
-        return
     q = Queue()
     p = Process(target=start_irace, args=(q, scenario2))
     p.start()
@@ -67,7 +61,6 @@ def test_no_hang2():
     t2 = Timer(BASE_TIME + 1, sigkill_process, args=(p,))
     t1.start()
     t2.start()
-    print("jfjfjfj")
     for i in range(BASE_TIME + 2):
         sleep(1)
         if not p.is_alive():
@@ -113,8 +106,6 @@ def test_correct_exit1():
     assert not q.empty()
 
 def test_correct_exit2():
-    if is_windows():
-        return
     q = Queue()
     p = Process(target=start_irace, args=(q, scenario2))
     p.start()


### PR DESCRIPTION
We feed the json serialized instances list to irace but at the `targetRunnerParallel` end, we swap it back with the original python objects. This allows a lot more objects to be pass though the instances list while leaving the log file more or less human readable at a glance.

This is built on top of PR #22. I think since that is going to get merged soon, I won't write this PR with main as a base. 

Closes #29.